### PR TITLE
Create examples folder and add an example dashboard for k8s

### DIFF
--- a/example/k8s/dashboard.json
+++ b/example/k8s/dashboard.json
@@ -1,0 +1,398 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 8,
+    "iteration": 1545919919137,
+    "links": [],
+    "panels": [
+      {
+        "cards": {
+          "cardHSpacing": 2,
+          "cardMinWidth": 5,
+          "cardRound": null,
+          "cardVSpacing": 2
+        },
+        "color": {
+          "cardColor": "#b4ff00",
+          "colorScale": "sqrt",
+          "colorScheme": "interpolateOranges",
+          "defaultColor": "#757575",
+          "exponent": 0.5,
+          "max": 5,
+          "min": 1,
+          "mode": "discrete",
+          "thresholds": [
+            {
+              "color": "#cca300",
+              "tooltip": "Pending",
+              "value": "1"
+            },
+            {
+              "color": "#9ac48a",
+              "tooltip": "Running",
+              "value": "2"
+            },
+            {
+              "color": "#bf1b00",
+              "tooltip": "Failed",
+              "value": "3"
+            },
+            {
+              "color": "#3f6833",
+              "tooltip": "Succeeded",
+              "value": "4"
+            },
+            {
+              "color": "#f9e2d2",
+              "tooltip": "Unknown",
+              "value": "5"
+            }
+          ]
+        },
+        "data": {
+          "decimals": null,
+          "unitFormat": "short"
+        },
+        "datasource": "prometheus",
+        "gridPos": {
+          "h": 16,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "highlightCards": true,
+        "id": 2,
+        "interval": "",
+        "legend": {
+          "show": true
+        },
+        "links": [],
+        "nullPointMode": "as empty",
+        "repeat": null,
+        "repeatDirection": null,
+        "targets": [
+          {
+            "expr": "kube_pod_status_phase{namespace=\"$namespace\", phase=\"Pending\"} == 1",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }}",
+            "refId": "A"
+          },
+          {
+            "expr": "(kube_pod_status_phase{namespace=\"$namespace\", phase=\"Running\"} == 1) * 2",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }}",
+            "refId": "B"
+          },
+          {
+            "expr": "(kube_pod_status_phase{namespace=\"$namespace\", phase=\"Failed\"} == 1) * 3",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }}",
+            "refId": "C"
+          },
+          {
+            "expr": "(kube_pod_status_phase{namespace=\"$namespace\", phase=\"Succeeded\"} == 1) * 4",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }}",
+            "refId": "D"
+          },
+          {
+            "expr": "(kube_pod_status_phase{namespace=\"$namespace\", phase=\"Unknown\"} == 1) * 5",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }}",
+            "refId": "E"
+          }
+        ],
+        "title": "Pod Status",
+        "tooltip": {
+          "show": true
+        },
+        "transparent": true,
+        "type": "flant-statusmap-panel",
+        "useMax": true,
+        "xAxis": {
+          "labelFormat": "%a %m/%d",
+          "minBucketWidthToShowWeekends": 4,
+          "show": true,
+          "showCrosshair": true,
+          "showWeekends": true
+        },
+        "yAxis": {
+          "show": true,
+          "showCrosshair": false
+        },
+        "yAxisSort": "a → z"
+      },
+      {
+        "cards": {
+          "cardHSpacing": 2,
+          "cardMinWidth": 5,
+          "cardRound": null,
+          "cardVSpacing": 2
+        },
+        "color": {
+          "cardColor": "#b4ff00",
+          "colorScale": "sqrt",
+          "colorScheme": "interpolateOranges",
+          "defaultColor": "#757575",
+          "exponent": 0.5,
+          "max": 5,
+          "min": 1,
+          "mode": "discrete",
+          "thresholds": [
+            {
+              "color": "#cca300",
+              "tooltip": "ContainerCreating",
+              "value": "1"
+            },
+            {
+              "color": "#890f02",
+              "tooltip": "CrashLoopBackOff",
+              "value": "2"
+            },
+            {
+              "color": "#bf1b00",
+              "tooltip": "ErrImagePull",
+              "value": "3"
+            },
+            {
+              "color": "#58140c",
+              "tooltip": "ImagePullBackOff",
+              "value": "4"
+            },
+            {
+              "color": "#7eb26d",
+              "tooltip": "Running",
+              "value": "5"
+            },
+            {
+              "color": "#052b51",
+              "tooltip": "Completed",
+              "value": "6"
+            },
+            {
+              "color": "#c15c17",
+              "tooltip": "ContainerCannotRun",
+              "value": "7"
+            },
+            {
+              "color": "#f9934e",
+              "tooltip": "Error",
+              "value": "8"
+            },
+            {
+              "color": "#eab839",
+              "tooltip": "OOMKilled",
+              "value": "9"
+            }
+          ]
+        },
+        "data": {
+          "decimals": null,
+          "unitFormat": "short"
+        },
+        "datasource": "prometheus",
+        "gridPos": {
+          "h": 16,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "highlightCards": true,
+        "id": 3,
+        "interval": "",
+        "legend": {
+          "show": true
+        },
+        "links": [],
+        "nullPointMode": "as empty",
+        "repeatDirection": null,
+        "targets": [
+          {
+            "expr": "kube_pod_container_status_waiting_reason{namespace=\"$namespace\", reason=\"ContainerCreating\"} == 1",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "A"
+          },
+          {
+            "expr": "(kube_pod_container_status_waiting_reason{namespace=\"$namespace\", reason=\"CrashLoopBackOff\"} == 1) * 2",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "B"
+          },
+          {
+            "expr": "(kube_pod_container_status_waiting_reason{namespace=\"$namespace\", reason=\"ErrImagePull\"} == 1) * 3",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "C"
+          },
+          {
+            "expr": "(kube_pod_container_status_waiting_reason{namespace=\"$namespace\", reason=\"ImagePullBackOff\"} == 1) * 4",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "D"
+          },
+          {
+            "expr": "(kube_pod_container_status_running{namespace=\"$namespace\"} == 1) * 5",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "E"
+          },
+          {
+            "expr": "(kube_pod_container_status_terminated_reason{namespace=\"$namespace\", reason=\"Completed\"} == 1) * 6",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "F"
+          },
+          {
+            "expr": "(kube_pod_container_status_terminated_reason{namespace=\"$namespace\", reason=\"ContainerCannotRun\"} == 1) * 7",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "G"
+          },
+          {
+            "expr": "(kube_pod_container_status_terminated_reason{namespace=\"$namespace\", reason=\"Error\"} == 1) * 8",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "H"
+          },
+          {
+            "expr": "(kube_pod_container_status_terminated_reason{namespace=\"$namespace\", reason=\"OOMKilled\"} == 1) * 9",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{ pod }} - {{ container }}",
+            "refId": "I"
+          }
+        ],
+        "title": "Container Status",
+        "tooltip": {
+          "show": true
+        },
+        "transparent": true,
+        "type": "flant-statusmap-panel",
+        "useMax": true,
+        "xAxis": {
+          "labelFormat": "%a %m/%d",
+          "minBucketWidthToShowWeekends": 4,
+          "show": true,
+          "showCrosshair": true,
+          "showWeekends": true
+        },
+        "yAxis": {
+          "show": true,
+          "showCrosshair": false
+        },
+        "yAxisSort": "a → z"
+      }
+    ],
+    "schemaVersion": 16,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "openshift-monitoring",
+            "value": "openshift-monitoring"
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(kube_pod_info, namespace)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Namespace",
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(kube_pod_info, namespace)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 2,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-3h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Pod status",
+    "uid": "x3PAP_ymk",
+    "version": 10
+  }


### PR DESCRIPTION
This PR adds an example folder for dashboards, which are ready to be used by newcomers instead of a rather vague README - in this case its k8s, suitable to be used with prometheus-operator.

Here's how it looks:

Pod status:
![pod-status](https://user-images.githubusercontent.com/114501/50483560-a2d04200-09ec-11e9-8613-dffca6e57af5.png)

More detailed container status:
![container-status](https://user-images.githubusercontent.com/114501/50483584-b8de0280-09ec-11e9-85e6-0ad684f3549f.png)

It also shows that alphabetical sorting is not really useful when pods (grafana and node-exporter) were restarted - I guess README.md deserves a better screenshot if you plan to do put it there