### PR TITLE
Restrict color scaling to min-max values in spectrum mode

### DIFF
--- a/src/color_legend.ts
+++ b/src/color_legend.ts
@@ -68,12 +68,8 @@ coreModule.directive('statusHeatmapLegend', function() {
         if (ctrl.bucketMatrix) {
           let rangeFrom = ctrl.bucketMatrix.minValue;
           let rangeTo = ctrl.bucketMatrix.maxValue;
-          let maxValue = panel.color.max || rangeTo;
-          let minValue = panel.color.min || rangeFrom;
-          if (panel.color.restrict) {
-            minValue = panel.color.min
-            maxValue = panel.color.max
-          }
+          let maxValue = panel.color.max != null ? panel.color.max : rangeTo;
+          let minValue = panel.color.min != null ? panel.color.min : rangeFrom;
 
           if (ctrl.bucketMatrix.noDatapoints) {
             if (!panel.color.max) {

--- a/src/color_legend.ts
+++ b/src/color_legend.ts
@@ -70,6 +70,10 @@ coreModule.directive('statusHeatmapLegend', function() {
           let rangeTo = ctrl.bucketMatrix.maxValue;
           let maxValue = panel.color.max || rangeTo;
           let minValue = panel.color.min || rangeFrom;
+          if (panel.color.restrict) {
+            minValue = panel.color.min
+            maxValue = panel.color.max
+          }
 
           if (ctrl.bucketMatrix.noDatapoints) {
             if (!panel.color.max) {

--- a/src/partials/options_editor.html
+++ b/src/partials/options_editor.html
@@ -127,12 +127,20 @@
   <div class="section gf-form-group" ng-show="ctrl.panel.color.mode !== 'discrete'">
     <h5 class="section-heading">Color scale</h5>
     <div class="gf-form">
-      <label class="gf-form-label width-8">Min value</label>
+      <label class="gf-form-label width-5">Min value</label>
       <input type="number" ng-model="ctrl.panel.color.min" class="gf-form-input width-5" placeholder="auto" data-placement="right" bs-tooltip="''" ng-change="ctrl.refresh()" ng-model-onblur>
+      <gf-form-switch class="gf-form" label-class="width-5"
+        label="Restrict" 
+        tooltip="'Color interpolation is restricted to start from Min Value when checked'" 
+        checked="ctrl.panel.color.restrictMin" on-change="ctrl.render()">
     </div>
     <div class="gf-form">
-      <label class="gf-form-label width-8">Max value</label>
+      <label class="gf-form-label width-5">Max value</label>
       <input type="number" ng-model="ctrl.panel.color.max" class="gf-form-input width-5" placeholder="auto" data-placement="right" bs-tooltip="''" ng-change="ctrl.refresh()" ng-model-onblur>
+      <gf-form-switch class="gf-form" label-class="width-5" 
+        label="Restrict"
+        tooltip="'Color interpolation is restricted to end at Max Value when checked'" 
+        checked="ctrl.panel.color.restrictMax" on-change="ctrl.render()">
     </div>
   </div>
 

--- a/src/partials/options_editor.html
+++ b/src/partials/options_editor.html
@@ -134,15 +134,6 @@
       <label class="gf-form-label width-8">Max value</label>
       <input type="number" ng-model="ctrl.panel.color.max" class="gf-form-input width-5" placeholder="auto" data-placement="right" bs-tooltip="''" ng-change="ctrl.refresh()" ng-model-onblur>
     </div>
-    <div>
-    <gf-form-switch class="gf-form" label-class="width-8"
-      label="Restrict" 
-      tooltip="'Color scaling is restricted to Min-Max Value range when checked'" 
-      checked="ctrl.panel.color.restrict" on-change="ctrl.render()">
-    </div>
-    <div class="gf-form" ng-show="ctrl.panel.color.restrict">
-      Color scale will be restricted to Min and Max values. They cannot be empty<br/>
-    </div>
   </div>
 
   <div class="section gf-form-group">

--- a/src/partials/options_editor.html
+++ b/src/partials/options_editor.html
@@ -127,20 +127,21 @@
   <div class="section gf-form-group" ng-show="ctrl.panel.color.mode !== 'discrete'">
     <h5 class="section-heading">Color scale</h5>
     <div class="gf-form">
-      <label class="gf-form-label width-5">Min value</label>
+      <label class="gf-form-label width-8">Min value</label>
       <input type="number" ng-model="ctrl.panel.color.min" class="gf-form-input width-5" placeholder="auto" data-placement="right" bs-tooltip="''" ng-change="ctrl.refresh()" ng-model-onblur>
-      <gf-form-switch class="gf-form" label-class="width-5"
-        label="Restrict" 
-        tooltip="'Color interpolation is restricted to start from Min Value when checked'" 
-        checked="ctrl.panel.color.restrictMin" on-change="ctrl.render()">
     </div>
     <div class="gf-form">
-      <label class="gf-form-label width-5">Max value</label>
+      <label class="gf-form-label width-8">Max value</label>
       <input type="number" ng-model="ctrl.panel.color.max" class="gf-form-input width-5" placeholder="auto" data-placement="right" bs-tooltip="''" ng-change="ctrl.refresh()" ng-model-onblur>
-      <gf-form-switch class="gf-form" label-class="width-5" 
-        label="Restrict"
-        tooltip="'Color interpolation is restricted to end at Max Value when checked'" 
-        checked="ctrl.panel.color.restrictMax" on-change="ctrl.render()">
+    </div>
+    <div>
+    <gf-form-switch class="gf-form" label-class="width-8"
+      label="Restrict" 
+      tooltip="'Color scaling is restricted to Min-Max Value range when checked'" 
+      checked="ctrl.panel.color.restrict" on-change="ctrl.render()">
+    </div>
+    <div class="gf-form" ng-show="ctrl.panel.color.restrict">
+      Color scale will be restricted to Min and Max values. They cannot be empty<br/>
     </div>
   </div>
 

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -368,6 +368,10 @@ export class StatusmapRenderer {
     let minValue = this.panel.color.min || this.bucketMatrix.minValue;
 
     if (this.panel.color.mode !== 'discrete') {
+      if (this.panel.color.restrict) {
+        maxValue =  this.panel.color.max;
+        minValue =  this.panel.color.min;
+      }
       this.colorScale = this.getColorScale(maxValue, minValue);
     }
     this.setOpacityScale(maxValue);

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -364,14 +364,10 @@ export class StatusmapRenderer {
   }
 
   addStatusmap():void {
-    let maxValue = this.panel.color.max || this.bucketMatrix.maxValue;
-    let minValue = this.panel.color.min || this.bucketMatrix.minValue;
+    let maxValue = this.panel.color.max != null ? this.panel.color.max : this.bucketMatrix.maxValue;
+    let minValue = this.panel.color.min != null ? this.panel.color.min : this.bucketMatrix.minValue;
 
     if (this.panel.color.mode !== 'discrete') {
-      if (this.panel.color.restrict) {
-        maxValue =  this.panel.color.max;
-        minValue =  this.panel.color.min;
-      }
       this.colorScale = this.getColorScale(maxValue, minValue);
     }
     this.setOpacityScale(maxValue);


### PR DESCRIPTION
I needed the functionality in #132 and I have implemented in my fork, thought I might as well open up a pull request too. 

I implemented a switch that enforces min and max values in the color scale interpolation. 
![image](https://user-images.githubusercontent.com/32689837/93008492-f2b6ba00-f57d-11ea-9362-fd0dd4e412c0.png)

Effectively, when restrict is off, and the series value is inside the range, color is interpolated for min and max values of the buckets as in the following picture:
![](https://user-images.githubusercontent.com/32689837/93008375-ac149000-f57c-11ea-99dc-64cba123aa6a.png)
When the restrict is on, color is interpolated for the given limit range.
![](https://user-images.githubusercontent.com/32689837/93008414-12011780-f57d-11ea-8b17-1079e465b92c.png)
