### PR TITLE
fix spectrum color null as zero

### DIFF
--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -578,8 +578,14 @@ export class StatusmapRenderer {
     if (this.panel.color.mode === 'opacity') {
       return this.panel.color.cardColor;
     } else if (this.panel.color.mode === 'spectrum') {
-      return this.colorScale(bucket.value);
-    } else if (this.panel.color.mode === 'discrete') {
+      if(bucket.value !== null) {
+        return this.colorScale(bucket.value);
+      } else {
+          if(this.panel.nullPointMode == 'as zero')  {
+            return this.colorScale(0);
+          }
+        }
+      } else if (this.panel.color.mode === 'discrete') {
       if (this.panel.seriesFilterIndex !== null && this.panel.seriesFilterIndex !== -1) {
         return this.ctrl.discreteExtraSeries.getBucketColorSingle(bucket.values[this.panel.seriesFilterIndex]);
       } else {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Fix 'display as zero' mode for nulls when spectrum color is used.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Without this fix nulls are displayed as black in 'as zero' mode.

![Снимок экрана 2021-06-03 в 10 56 17](https://user-images.githubusercontent.com/1055474/120770889-4bbce880-c527-11eb-93a5-4ab9ba1d42b9.png)


<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
