### PR TITLE
fix: Grafana 8.1+ compatibility

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -334,6 +334,11 @@ class StatusHeatmapCtrl extends MetricsPanelCtrl {
   }
 
   issueQueries(datasource: any) {
+    // Grafana 8.1+: there is no updateTimeRange call before initial issueQueries.
+    // https://github.com/grafana/grafana/commit/6f38883583c4c43af149f68db482b39a3240ec95
+    if (!this.range) {
+      this.updateTimeRange(datasource);
+    }
     this.annotationsPromise = this.annotationsSrv.getAnnotations({
       dashboard: this.dashboard,
       panel: this.panel,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Dasboard with statusmap fire this error in Grafana 8.1+: 
```
Annotation Query Failed
Cannot read property 'to' of undefined
```

#### What this PR does / why we need it

Quote from https://github.com/flant/grafana-statusmap/issues/219#issuecomment-921849398 :

> I'm suspecting this commit grafana/grafana@6f38883.
> The `updateTimeRange` is no longer called before `issueQueries` so `this.range` is not set until `super.issueQueries` is called.



<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- Grafana 8.1+ compatibility
```
