### PR TITLE
CI: enhance workflow for branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
+      - main
+      - fix_*
+      - feat_*
+
+env:
+  WITH_NODE_VERSION: "14.x"
+  WITH_GO_VERSION: "1.15"
 
 jobs:
   build:
@@ -17,32 +21,106 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.4.1
         with:
-          node-version: "14.x"
+          node-version: ${{env.WITH_NODE_VERSION}}
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{env.WITH_GO_VERSION}}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache yarn cache
+      - name: Restore yarn cache
         uses: actions/cache@v2.1.6
-        id: cache-yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          key: ${{ runner.os }}-${{ env.WITH_NODE_VERSION }}-yarn-${{ hashFiles('yarn.lock') }}
 
-      - name: Cache node_modules
-        id: cache-node-modules
+      - name: Install dependencies with yarn
+        run: yarn install --frozen-lockfile  --prefer-offline
+
+      - name: Build and test plugin
+        run: |
+          yarn build
+          ls -la dist
+
+      - name: Get plugin metadata
+        id: metadata
+        run: |
+          export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
+          export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
+          export GRAFANA_PLUGIN_TYPE=$(cat dist/plugin.json | jq -r .type)
+          export GRAFANA_PLUGIN_UPDATED=$(cat dist/plugin.json | jq -r .info.updated)
+          export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
+          export GRAFANA_PLUGIN_ARTIFACT_CHECKSUM=${GRAFANA_PLUGIN_ARTIFACT}.md5
+          export GRAFANA_PLUGIN_RELEASE_NAME="${GRAFANA_PLUGIN_VERSION} (${GRAFANA_PLUGIN_UPDATED})"
+
+          echo "::set-output name=plugin-id::${GRAFANA_PLUGIN_ID}"
+          echo "::set-output name=plugin-version::${GRAFANA_PLUGIN_VERSION}"
+          echo "::set-output name=plugin-type::${GRAFANA_PLUGIN_TYPE}"
+          echo "::set-output name=archive::${GRAFANA_PLUGIN_ARTIFACT}"
+          echo "::set-output name=archive-checksum::${GRAFANA_PLUGIN_ARTIFACT_CHECKSUM}"
+          echo "::set-output name=release-name::${GRAFANA_PLUGIN_RELEASE_NAME}"
+
+          # Get the latest section in CHANGELOG without it's header.
+          awk '/^$/{next} /^## / {s++;next} s == 1 {print}' CHANGELOG.md > release_notes.md
+          echo "::set-output name=release_notes_path::release_notes.md"
+
+      - name: Sign plugin
+        env:
+          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }} # Requires a Grafana API key from Grafana.com.
+        run: |
+          echo "Patch @grafana/toolkit to prevent TypeError in some cases."
+          # manifest.js
+          #- if ((err_1.response && err_1.response.data) || err_1.response.data.message) {
+          #+ if (err_1.response && err_1.response.data && err_1.response.data.message) {
+          pushd node_modules/@grafana/toolkit/src/plugins
+          echo LS0tIGEvbWFuaWZlc3QuanMJMjAyMS0xMS0xOSAyMTo0Njo1Mi4wMDAwMDAwMDAgKzAzMDAKKysrIGIvbWFuaWZlc3QuanMJMjAyMS0xMS0xOSAyMTo0NzoyNS4wMDAwMDAwMDAgKzAzMDAKQEAgLTE1NSw3ICsxNTUsNyBAQAogICAgICAgICAgICAgICAgICAgICByZXR1cm4gWzIgLypyZXR1cm4qLywgaW5mby5kYXRhXTsKICAgICAgICAgICAgICAgICBjYXNlIDM6CiAgICAgICAgICAgICAgICAgICAgIGVycl8xID0gX2Euc2VudCgpOwotICAgICAgICAgICAgICAgICAgICBpZiAoKGVycl8xLnJlc3BvbnNlICYmIGVycl8xLnJlc3BvbnNlLmRhdGEpIHx8IGVycl8xLnJlc3BvbnNlLmRhdGEubWVzc2FnZSkgeworICAgICAgICAgICAgICAgICAgICBpZiAoZXJyXzEucmVzcG9uc2UgJiYgZXJyXzEucmVzcG9uc2UuZGF0YSAmJiBlcnJfMS5yZXNwb25zZS5kYXRhLm1lc3NhZ2UpIHsKICAgICAgICAgICAgICAgICAgICAgICAgIHRocm93IG5ldyBFcnJvcignRXJyb3Igc2lnbmluZyBtYW5pZmVzdDogJyArIGVycl8xLnJlc3BvbnNlLmRhdGEubWVzc2FnZSk7CiAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgdGhyb3cgbmV3IEVycm9yKCdFcnJvciBzaWduaW5nIG1hbmlmZXN0OiAnICsgZXJyXzEubWVzc2FnZSk7Cg== | base64 -d | patch -p1
+          popd
+          # yarn sign always exits with code 0.
+          set -o pipefail
+          yarn sign 2>&1 | tee >(grep -q -i error && exit 1 || exit 0)
+          # More checks.
+          if [[ ! -f dist/MANIFEST.txt ]] ; then
+            echo "Error: dist/MANIFEST.txt is not found."
+            ls -la dist
+            exit 1
+          fi
+
+      - name: Package plugin
+        id: package-plugin
+        run: |
+          mv dist ${{ steps.metadata.outputs.plugin-id }}
+          zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
+          md5sum ${{ steps.metadata.outputs.archive }} > ${{ steps.metadata.outputs.archive-checksum }}
+          echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
+
+      - name: Get plugin-validator last commit
+        run: |
+          git ls-remote https://github.com/grafana/plugin-validator refs/heads/master | tee plugin-validator-last-commit
+
+      - name: Restore plugin-validator binary
         uses: actions/cache@v2.1.6
+        id: plugin-validator-cache
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          path: ./plugin-validator
+          key: ${{ runner.os }}-${{ env.WITH_GO_VERSION }}-plugin-validator-${{ hashFiles('plugin-validator-last-commit') }}
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Build plugin-validator utility
+        if: steps.plugin-validator-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/grafana/plugin-validator
+          cd ./plugin-validator
+          go build ./pkg/cmd/plugincheck2
 
-      - name: Build and test frontend
-        run: yarn build
+      - name: Validate plugin for publishing
+        run: |
+          ./plugin-validator/plugincheck2 -config ./plugin-validator/config/default.yaml ${{ steps.metadata.outputs.archive }}
+
+      - name: Release body preview
+        run: |
+          echo "Title: ${{ steps.metadata.outputs.release-name }}"
+          echo "Body:"
+          cat ${{ steps.metadata.outputs.release_notes_path }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,68 +1,73 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*" # Run workflow on version tags, e.g. v1.0.0.
+  workflow_dispatch:
+    inputs:
+      future_tag:
+        description: 'A new tag name for release in form vX.Y.Z'
+        required: true
+
+env:
+  WITH_NODE_VERSION: "14.x"
+  WITH_GO_VERSION: "1.15"
 
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    env:
+      FUTURE_TAG: ${{ github.event.inputs.future_tag }}
     steps:
       - uses: actions/checkout@v2.4.0
+
+      - name: Check plugin version
+        run: |
+          export PACKAGE_VERSION=$(jq -r .version package.json)
+
+          if [[ "v${PACKAGE_VERSION}" != "${FUTURE_TAG}" ]; then
+            printf "\033[0;31mPlugin version 'v${PACKAGE_VERSION}' doesn't match future tag name\033[0m\n"
+            printf "Fix package.json please."
+            exit 1
+          fi
+
+      - name: Check CHANGELOG.md
+        run: |
+          if ! grep "## ${FUTURE_TAG}" CHANGELOG.md ; then
+            echo "No release notes for version v${FUTURE_TAG} in CHANGELOG.md"
+            echo "CHANGELOG.md head:"
+            head -n 10 CHANGELOG.md
+          fi
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.4.1
         with:
-          node-version: "14.x"
+          node-version: ${{env.WITH_NODE_VERSION}}
 
       - name: Setup Go environment
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: ${{env.WITH_GO_VERSION}}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache yarn cache
+      - name: Restore yarn cache
         uses: actions/cache@v2.1.6
-        id: cache-yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          key: ${{ runner.os }}-${{ env.WITH_NODE_VERSION }}-yarn-${{ hashFiles('yarn.lock') }}
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2.1.6
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+      - name: Install dependencies with yarn
+        run: yarn install --frozen-lockfile  --prefer-offline
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile;
-        if: |
-          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
-          steps.cache-node-modules.outputs.cache-hit != 'true'
-
-      - name: Build and test frontend
-        run: yarn build
-
-      - name: Sign plugin
-        run: yarn sign
-        env:
-          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }} # Requires a Grafana API key from Grafana.com.
+      - name: Build and test plugin
+        run: |
+          yarn build
+          ls -la dist
 
       - name: Get plugin metadata
         id: metadata
         run: |
-          sudo apt-get install jq
-
           export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
           export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
           export GRAFANA_PLUGIN_TYPE=$(cat dist/plugin.json | jq -r .type)
@@ -78,17 +83,30 @@ jobs:
           echo "::set-output name=archive-checksum::${GRAFANA_PLUGIN_ARTIFACT_CHECKSUM}"
           echo "::set-output name=release-name::${GRAFANA_PLUGIN_RELEASE_NAME}"
 
-          echo ::set-output name=github-tag::${GITHUB_REF#refs/*/}
-
-      - name: Read changelog
-        id: changelog
-        run: |
           # Get the latest section in CHANGELOG without it's header.
           awk '/^$/{next} /^## / {s++;next} s == 1 {print}' CHANGELOG.md > release_notes.md
-          echo "::set-output name=path::release_notes.md"
+          echo "::set-output name=release_notes_path::release_notes.md"
 
-      - name: Check package version
-        run: if [ "v${{ steps.metadata.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name\033[0m\n"; exit 1; fi
+      - name: Sign plugin
+        env:
+          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }} # Requires a Grafana API key from Grafana.com.
+        run: |
+          echo "Patch @grafana/toolkit to prevent TypeError in some cases."
+          # manifest.js
+          #- if ((err_1.response && err_1.response.data) || err_1.response.data.message) {
+          #+ if (err_1.response && err_1.response.data && err_1.response.data.message) {
+          pushd node_modules/@grafana/toolkit/src/plugins
+          echo LS0tIGEvbWFuaWZlc3QuanMJMjAyMS0xMS0xOSAyMTo0Njo1Mi4wMDAwMDAwMDAgKzAzMDAKKysrIGIvbWFuaWZlc3QuanMJMjAyMS0xMS0xOSAyMTo0NzoyNS4wMDAwMDAwMDAgKzAzMDAKQEAgLTE1NSw3ICsxNTUsNyBAQAogICAgICAgICAgICAgICAgICAgICByZXR1cm4gWzIgLypyZXR1cm4qLywgaW5mby5kYXRhXTsKICAgICAgICAgICAgICAgICBjYXNlIDM6CiAgICAgICAgICAgICAgICAgICAgIGVycl8xID0gX2Euc2VudCgpOwotICAgICAgICAgICAgICAgICAgICBpZiAoKGVycl8xLnJlc3BvbnNlICYmIGVycl8xLnJlc3BvbnNlLmRhdGEpIHx8IGVycl8xLnJlc3BvbnNlLmRhdGEubWVzc2FnZSkgeworICAgICAgICAgICAgICAgICAgICBpZiAoZXJyXzEucmVzcG9uc2UgJiYgZXJyXzEucmVzcG9uc2UuZGF0YSAmJiBlcnJfMS5yZXNwb25zZS5kYXRhLm1lc3NhZ2UpIHsKICAgICAgICAgICAgICAgICAgICAgICAgIHRocm93IG5ldyBFcnJvcignRXJyb3Igc2lnbmluZyBtYW5pZmVzdDogJyArIGVycl8xLnJlc3BvbnNlLmRhdGEubWVzc2FnZSk7CiAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgdGhyb3cgbmV3IEVycm9yKCdFcnJvciBzaWduaW5nIG1hbmlmZXN0OiAnICsgZXJyXzEubWVzc2FnZSk7Cg== | base64 -d | patch -p1
+          popd
+          # yarn sign always exits with code 0.
+          set -o pipefail
+          yarn sign 2>&1 | tee >(grep -q -i error && exit 1 || exit 0)
+          # More checks.
+          if [[ ! -f dist/MANIFEST.txt ]] ; then
+            echo "Error: dist/MANIFEST.txt is not found."
+            ls -la dist
+            exit 1
+          fi
 
       - name: Package plugin
         id: package-plugin
@@ -98,28 +116,40 @@ jobs:
           md5sum ${{ steps.metadata.outputs.archive }} > ${{ steps.metadata.outputs.archive-checksum }}
           echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
 
-      - name: Lint plugin
+      - name: Get plugin-validator last commit
+        run: |
+          git ls-remote https://github.com/grafana/plugin-validator refs/heads/master | tee plugin-validator-last-commit
+
+      - name: Restore plugin-validator binary
+        uses: actions/cache@v2.1.6
+        id: plugin-validator-cache
+        with:
+          path: ./plugin-validator
+          key: ${{ runner.os }}-${{ env.WITH_GO_VERSION }}-plugin-validator-${{ hashFiles('plugin-validator-last-commit') }}
+
+      - name: Build plugin-validator utility
+        if: steps.plugin-validator-cache.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/pkg/cmd/plugincheck2
-          go install
-          popd
-          # Ignore error about twitter.com link :(
-          # (https://twitter.com/flant_com) (`400 Bad Request`).
-          plugincheck2 ${{ steps.metadata.outputs.archive }} || true
+          cd ./plugin-validator
+          go build ./pkg/cmd/plugincheck2
 
-      - name: Create release
+      - name: Validate plugin for publishing
+        run: |
+          ./plugin-validator/plugincheck2 -config ./plugin-validator/config/default.yaml ${{ steps.metadata.outputs.archive }}
+
+      - name: Create draft release
         id: create_release
         uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ env.FUTURE_TAG }}
           release_name: ${{ steps.metadata.outputs.release-name }}
-          body_path: ${{ steps.changelog.outputs.path }}
+          body_path: ${{ steps.metadata.outputs.release_notes_path }}
           draft: true
 
-      - name: Add plugin to release
+      - name: Add plugin archive to release
         id: upload-plugin-asset
         uses: actions/upload-release-asset@v1.0.2
         env:
@@ -141,8 +171,10 @@ jobs:
           asset_name: ${{ steps.metadata.outputs.archive-checksum }}
           asset_content_type: text/plain
 
-      - name: Publish to Grafana.com
+      - name: Note about publishing to Grafana.com
         run: |
-          echo A draft release has been created for your plugin. Please review and publish it. Then submit your plugin to grafana.com/plugins by opening a PR to https://github.com/grafana/grafana-plugin-repository with the following entry:
-          echo
-          echo '{ "id": "${{ steps.metadata.outputs.plugin-id }}", "type": "${{ steps.metadata.outputs.plugin-type }}", "url": "https://github.com/${{ github.repository }}", "versions": [ { "version": "${{ steps.metadata.outputs.plugin-version }}", "commit": "${{ github.sha }}", "url": "https://github.com/${{ github.repository }}", "download": { "any": { "url": "https://github.com/${{ github.repository }}/releases/download/v${{ steps.metadata.outputs.plugin-version }}/${{ steps.metadata.outputs.archive }}", "md5": "${{ steps.package-plugin.outputs.checksum }}" } } } ] }' | jq .
+          echo A draft release has been created for your plugin. Please review and publish it. Then submit your plugin using grafana.com account.
+          echo "Archive URL:"
+          echo "${{ steps.upload-plugin-asset.outputs.browser_download_url }}"
+          echo "MD5 URL:"
+          echo "${{ steps.upload-checksum-asset.outputs.browser_download_url }}"


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

I break signing with an invalid symbol in the new token, but `yarn sign` doesn't warn me.

I want to run package, signing, and plugin-validator operations for branches.

I want to run 'release' workflow with future tag name to check if everything is ok and then click "Publish" to create tag. Triggering 'release' on 'push tag' is a run-once operation and is frustrating.



<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

- Simplify caching yarn dependencies
- Add patch for @grafana/toolkit to not ignore some errors.
- Use plugincheck2, cache its binary.
- Remove pull_request trigger, as it doubles events with push.
- Exit code 1 on errors in 'yarn sign'.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
