### PR TITLE
fix: proper fallback to timeseries data format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.1
+
+- Fix fallback to timeseries for Grafana 6.x
+- Change docker-compose.yaml to work with Grafana 6.x
+
 ## v0.5.0
 
 - Support DataFrames. (#239)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,3 +14,20 @@ docker run --rm -it -v $PWD:/var/lib/grafana/plugins/flant-statusmap-panel \
 The `-v` flag exposes plugin directory from your machine to Grafana container. Now run `yarn watch` to compile `dist` directory and follow changes in src directory.
 
 
+## Compatibility
+
+- @grafana/data available for Angular plugins since 6.3.0 https://github.com/grafana/grafana/blob/v6.3.0/public/app/features/plugins/plugin_loader.ts#L94
+- useDataFrames presents in graph plugin since 6.4.0 https://github.com/grafana/grafana/blob/v6.4.0/public/app/plugins/panel/graph/module.ts#L145
+- Object based events are in use since 6.5.0
+- It seems @grafana/data contains PanelEvents.dataFramesReceived since 7.0.0, older versions use CoreEvents.dataFramesReceived
+
+## Docker compose
+
+Use GRAFANA_VERSION environment variable to run plugin in specific Grafana version:
+
+```
+$ GRAFANA_VERSION=6.7.4 docker-compose up
+...
+grafana_1  | t=2022-05-05T08:16:54+0000 lvl=info msg="Starting Grafana" logger=server version=6.7.4 commit=8e44bbc5f5 branch=HEAD compiled=2020-05-26T17:35:38+0000
+...
+```

--- a/README.md
+++ b/README.md
@@ -19,18 +19,21 @@ Panel to show discrete statuses of multiple targets over time.
 * Grouping values into rows and buckets using legend from query
 * User defined color mapping
 * Multiple values in bucket are displayed via tooltip
+* Configurable tooltip items
+* Pagination for rows
 * Increasing rows/buckets' interval for better visual representation
 * Representing null values as empty bucket or zero value
 
 ### Supported environment
 
-* Tested with datasources:
+* Tested with:
   - Prometheus
   - InfluxDB
   - Mysql
-* Supported Grafana versions:
-  - 6.7+ to 8.2+
-  - use (release 0.4.2)[https://github.com/flant/grafana-statusmap/releases/tag/v0.4.2] for 6.6 and earlier
+  - Grafana 7.x, 8.x
+* Support for earlier Grafana versions:
+  - 0.5.x versions should work in Grafana 6.5.x - 6.7.x with timeseries data format
+  - (0.4.2)[https://github.com/flant/grafana-statusmap/releases/tag/v0.4.2] should work in Grafana 5.4.x - 6.4.x
 
 ## Motivation
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,13 @@
 version: "3"
 services:
   grafana:
-    image: grafana/grafana:8.4.5
+    image: grafana/grafana:${GRAFANA_VERSION:-8.5.2}
     ports:
       - "3000:3000"
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: 1
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
-      GF_INSTALL_PLUGINS: marcusolsson-static-datasource,https://github.com/flant/grafana-statusmap/releases/download/v0.5.0/flant-statusmap-panel-0.5.0.zip;flant-statusmap-panel
+      GF_INSTALL_PLUGINS: marcusolsson-static-datasource,https://github.com/flant/grafana-statusmap/releases/download/v0.5.1/flant-statusmap-panel-0.5.1.zip;flant-statusmap-panel
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/dashboards/statusmap.json
     volumes:
       - ./provisioning:/etc/grafana/provisioning

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flant-statusmap-panel",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Grafana panel plugin to visualize status of multiple objects over time",
   "main": "README.md",
   "scripts": {

--- a/provisioning/dashboards/providers.yaml
+++ b/provisioning/dashboards/providers.yaml
@@ -6,7 +6,7 @@ providers:
     # <int> Org id. Default to 1
     orgId: 1
     # <string> name of the dashboard folder.
-    folder: General
+    folder: ""
     # <string> folder UID. will be automatically generated if not specified
     folderUid: ""
     # <string> provider type. Default to 'file'

--- a/src/module.ts
+++ b/src/module.ts
@@ -223,8 +223,8 @@ class StatusHeatmapCtrl extends MetricsPanelCtrl {
     if (majorVersion >= 7) {
       // Support data frames for 7.0+
       (this as any).useDataFrames = true;
-      this.events.on(PanelEvents.dataSnapshotLoad, this.onDataFramesReceived.bind(this));
       this.events.on(PanelEvents.dataFramesReceived, this.onDataFramesReceived.bind(this));
+      this.events.on(PanelEvents.dataSnapshotLoad, this.onDataFramesReceived.bind(this));
       this.processor = new DataProcessor(this.panel, majorVersion);
     } else {
       // Fallback to support only timeseries data format.

--- a/src/module.ts
+++ b/src/module.ts
@@ -209,9 +209,7 @@ class StatusHeatmapCtrl extends MetricsPanelCtrl {
     this.annotationsSrv = annotationsSrv;
 
     this.events.on(PanelEvents.render, this.onRender.bind(this));
-    this.events.on(PanelEvents.dataReceived, this.onDataReceived.bind(this));
     this.events.on(PanelEvents.dataError, this.onDataError.bind(this));
-    this.events.on(PanelEvents.dataSnapshotLoad, this.onDataReceived.bind(this));
     this.events.on(PanelEvents.editModeInitialized, this.onInitEditMode.bind(this));
     this.events.on(PanelEvents.refresh, this.postRefresh.bind(this));
     // custom event from rendering.js
@@ -222,14 +220,16 @@ class StatusHeatmapCtrl extends MetricsPanelCtrl {
     console.log('Grafana buildInfo:', config.buildInfo);
 
     const majorVersion = parseInt(config.buildInfo.version.split('.', 2)[0], 10);
-    if (majorVersion <= 6) {
-      // data will fall into onDataReceived() with series data format
-    } else {
-      // table like DataFrame[] data format for both table and series data mode
+    if (majorVersion >= 7) {
+      // Support data frames for 7.0+
       (this as any).useDataFrames = true;
-      this.events.on(PanelEvents.dataFramesReceived, this.onDataFramesReceived.bind(this));
       this.events.on(PanelEvents.dataSnapshotLoad, this.onDataFramesReceived.bind(this));
+      this.events.on(PanelEvents.dataFramesReceived, this.onDataFramesReceived.bind(this));
       this.processor = new DataProcessor(this.panel, majorVersion);
+    } else {
+      // Fallback to support only timeseries data format.
+      this.events.on(PanelEvents.dataReceived, this.onDataReceived.bind(this));
+      this.events.on(PanelEvents.dataSnapshotLoad, this.onDataReceived.bind(this));
     }
   }
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -30,8 +30,8 @@
   },
 
   "dependencies": {
-    "grafanaDependency": ">=6.7.0",
-    "grafanaVersion": "6.7.x",
+    "grafanaDependency": ">=7.0.0",
+    "grafanaVersion": "7.0.x",
     "plugins": [ ]
   }
 }


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

- fix: fallback to timeseries data format for 6.x versions only, enable data frames for 7.0-7.4
- fix docker compose to work with Grafana 6.7


<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

It was found that v0.5.0 still uses timeseries data format in Grafana 7.0-7.4.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
